### PR TITLE
Add AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,124 @@
+# AGENTS.md
+
+This file provides guidance to all AI coding agents (including Claude, Codex, Copilot, etc.) working in this repository.
+
+## Project Overview
+
+**athena** is a monorepo containing client applications, backend services, and shared libraries.
+
+| Layer              | Tech Stack        | Location  |
+| ------------------ | ----------------- | --------- |
+| Client apps        | Next.js (Node)    | `client/` |
+| Mobile Hybrid apps | Expo/React-Native | `mobile/` |
+| Backend services   | .NET Core         | `server/` |
+| Shared libraries   | Cross-platform    | `shared/` |
+
+## Repository Structure
+
+```
+> athena
+	> client	# client applications (next.js)
+		> athena-web
+	> mobile	# mobile applications (expo/react-native)
+		> athena-app
+	> server	# backend services (.net core)
+		> athena-api
+	> shared	# shared libraries
+		> athena-dotnet
+		> athena-nodejs
+	- AGENTS.md	# instructions for all AI agents (this file)
+	- CLAUDE.md	# intructions specifically for claude
+	- README.md
+```
+
+## Environment Requirements
+
+| Tool     | Minimum Version |
+| -------- | --------------- |
+| Bun      | 1.x             |
+| .NET SDK | 9.0             |
+| Node.js  | 22.x (for Expo) |
+
+## Build & Test Commands
+
+### Frontend / TypeScript (Bun)
+
+Run these from within the relevant app directory under `client/athena-*/` or `mobile/athena-*/`.
+
+```sh
+bun install       # Install dependencies
+bun run build     # Build
+bun run dev       # Dev server
+bun run lint      # Lint
+bun test          # Test
+```
+
+### Backend (.NET Core)
+
+Run these from within the relevant project/solution directory under `server/athena-*/`.
+
+```sh
+dotnet restore    # Restore dependencies
+dotnet build      # Build
+dotnet run        # Run
+dotnet test       # Test
+dotnet format     # Lint / format
+```
+
+## Conventions
+
+### General
+
+- Keep changes scoped to the relevant project within the monorepo.
+- Do not introduce cross-project dependencies without discussion.
+- Prefer editing existing files over creating new ones.
+- One logical change per commit.
+- Write clear, concise commit messages.
+
+### Frontend / TypeScript
+
+- Use Bun as the package manager and runtime for all TypeScript apps and libraries. Do not use `npm`, `yarn`, or `pnpm`.
+- Use TypeScript for all new code.
+- Use Biome for linting and formatting. Do not use ESLint or Prettier.
+- Use functional React components with hooks.
+- Prefer named exports over default exports.
+
+### Backend (.NET Core)
+
+- Follow standard C# naming conventions (PascalCase for public members, camelCase for locals).
+- Use async/await for all I/O-bound operations.
+- Keep controllers thin — push logic into services.
+- Use dependency injection; do not instantiate services directly.
+- Prefer DDD-style architecture and boundaries.
+- Always use the `.slnx` solution format. Do not use the legacy `.sln` format.
+- Use PostgreSQL as the database and Entity Framework Core as the ORM.
+- Use EF Core migrations for schema changes. Do not write raw DDL.
+
+### Shared Libraries
+
+- Shared libraries in `shared/` must not depend on app- or service-specific code.
+- Keep library APIs minimal and well-documented.
+- Create one library per logical responsibility.
+  - For .NET Core libraries, create a new solution for the logical grouping.
+  - For Node.js/TypeScript libraries, create a new package for the logical grouping. Use Bun as the package manager.
+
+## Testing
+
+- All new features and bug fixes should include tests.
+- Frontend: use the testing framework configured in each app (e.g., Jest, Vitest).
+- Backend: always use xUnit test projects.
+- Run the relevant test suite before submitting changes.
+
+## Branch Strategy
+
+- `main` is the primary branch and should always be in a clean, deployable state.
+- Tags represent versions of the codebase that made it to production.
+- All work branches should be created from `main` and kept short-lived.
+- Branch names must include the related GitHub issue number: `<type>/<issue>/<short-description>` (e.g., `issues/042/user-auth`, `hotfix/103/-null-ref`).
+- Merge back to `main` via pull request.
+
+## Security
+
+- Never commit secrets, credentials, or connection strings.
+- Use environment variables or secret managers for sensitive configuration.
+- Do not disable SSL/TLS verification or security middleware.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md
+
+This file provides Claude-specific guidance on top of the shared rules in `AGENTS.md`. Claude should read both files; `AGENTS.md` for general project rules, this file for Claude-specific behavior.
+
+## Reading Order
+
+1. Read `AGENTS.md` first — it contains project overview, structure, build commands, and conventions that apply to all agents.
+2. Read this file for Claude-specific instructions.
+3. If a subdirectory contains its own `CLAUDE.md`, read that too for project-specific overrides.
+
+## Claude-Specific Behavior
+
+### Tool Usage
+
+- Use the Grep and Glob tools to search the codebase — do not shell out to `grep`, `rg`, or `find`.
+- Use the Read tool to read files — do not use `cat`, `head`, or `tail`.
+- Use the Edit tool for targeted changes — do not use `sed` or `awk`.
+- Run build and test commands via the Bash tool.
+
+### Working in the Monorepo
+
+- Before making changes, identify which project(s) under `client/`, `mobile/`, `server/`, or `shared/` are affected.
+- Run builds and tests from the specific project directory (e.g., `client/athena-web/`, `server/athena-api/`), not the repo root, unless a root-level script exists for that purpose.
+- When a change spans multiple projects (e.g., a shared library and a consuming service), make and verify changes in dependency order: shared → server → client/mobile.
+
+### Code Generation
+
+- **Frontend**: Generate TypeScript. Use `import`/`export` syntax (ESM). Do not use `require()`.
+- **Backend**: Generate C# targeting the .NET version specified in each project's `global.json` or `.csproj`. Use file-scoped namespaces and nullable reference types.
+- Do not add boilerplate comments like `// TODO: implement` or `// Add your code here`.
+- Do not add XML doc comments or JSDoc unless the user asks for documentation.
+
+### Git Workflow
+
+- Do not commit unless explicitly asked.
+- Do not push unless explicitly asked.
+- Do not amend commits unless explicitly asked.
+- When committing, stage only the files relevant to the change — avoid `git add -A`.
+
+### Asking vs. Acting
+
+- If a task is ambiguous or could affect multiple projects, ask for clarification before proceeding.
+- If unsure which project a file belongs to, explore the directory structure first.
+- For destructive or hard-to-reverse operations, confirm with the user before executing.


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` with shared guidance for all AI coding agents: project overview, repo structure, environment requirements, build/test commands, coding conventions, testing, branch strategy, and security rules.
- Add `CLAUDE.md` with Claude-specific instructions: tool usage, monorepo workflow, code generation conventions, git workflow, and when to ask vs. act.

Closes #1

## Test plan
- [ ] Verify both files render correctly on GitHub
- [ ] Confirm Claude Code picks up instructions from both files in new conversations